### PR TITLE
Add support for BuddyPress registration form.

### DIFF
--- a/base-class.php
+++ b/base-class.php
@@ -17,6 +17,10 @@ class Ncr_No_Captcha_Recaptcha {
 
 	static protected $plugin_options;
 
+	static protected $script_handle;
+
+	static protected $textdomain;
+
 	public static function initialize() {
 
 		self::$plugin_options = get_option( 'ncr_options' );
@@ -31,6 +35,9 @@ class Ncr_No_Captcha_Recaptcha {
 
 		self::$error_message = self::$plugin_options['error_message'];
 
+		self::$script_handle = 'g-recaptcha';
+
+		self::$textdomain = 'ncr-captcha';
 
 		add_action( 'plugins_loaded', array( __CLASS__, 'load_plugin_textdomain' ) );
 
@@ -41,6 +48,10 @@ class Ncr_No_Captcha_Recaptcha {
 
 			add_action( 'login_enqueue_scripts', array( __CLASS__, 'default_wp_login_reg_css' ) );
 		}
+
+		// Add the "async" attribute to our registered script.
+		add_filter( 'script_loader_tag',  array( __CLASS__, 'add_async_attribute' ), 10, 2 );
+
 	}
 
 	public static function load_plugin_textdomain() {
@@ -63,6 +74,39 @@ class Ncr_No_Captcha_Recaptcha {
 		echo '<script src="https://www.google.com/recaptcha/api.js' . $lang . '" async defer></script>' . "\r\n";
 	}
 
+	/**
+	* Enqueue the Google ReCAPTCHA script using the WP system.
+	*
+	* @since 1.0.3
+	*/
+	public static function enqueue_header_script() {
+
+		$lang_option = self::$plugin_options['language'];
+
+		// if language is empty (auto detected chosen) do nothing otherwise add the lang query to the
+		// reCAPTCHA script url
+		if ( isset( $lang_option ) && ( ! empty( $lang_option ) ) ) {
+			$lang = "?hl=$lang_option";
+		} else {
+			$lang = '';
+		}
+
+		$src = 'https://www.google.com/recaptcha/api.js' . $lang;
+
+		wp_enqueue_script( self::$script_handle, $src, false, false, true );
+	}
+
+	/**
+	* Add the "async" attribute to our registered script.
+	*
+	* @since 1.0.3
+	*/
+	public static function add_async_attribute( $tag, $handle ) {
+	    if ( $handle == self::$script_handle ) {
+	       $tag = str_replace( ' src', ' async="async" src', $tag );
+	    }
+	    return $tag;
+	}
 
 	/** Increase the width of login/registration form */
 	public static function default_wp_login_reg_css() {
@@ -117,10 +161,11 @@ class Ncr_No_Captcha_Recaptcha {
 		check_admin_referer( "activate-plugin_{$plugin}" );
 
 		$default_options = array(
-			'captcha_registration' => 'yes',
-			'captcha_comment'      => 'yes',
-			'theme'                => 'light',
-			'error_message'        => '<strong>ERROR</strong>: Please retry CAPTCHA'
+			'captcha_registration'    => 'yes',
+			'captcha_registration_bp' => 'no',
+			'captcha_comment'         => 'yes',
+			'theme'                   => 'light',
+			'error_message'           => '<strong>ERROR</strong>: Please retry CAPTCHA'
 		);
 
 		add_option( 'ncr_options', $default_options );

--- a/buddypress-registration.php
+++ b/buddypress-registration.php
@@ -1,0 +1,68 @@
+<?php
+/**
+* Add the Google No ReCAPTCHA to the BuddyPress registration form.
+*
+* @since 1.0.3
+*/
+
+class Ncr_BP_Registration_Captcha extends Ncr_No_Captcha_Recaptcha {
+
+	public static function initialize() {
+		// Initialize if the site admin has enabled the CAPTCHA for the BP registration page.
+		if ( isset( self::$plugin_options['captcha_registration_bp'] ) && self::$plugin_options['captcha_registration_bp'] == 'yes') {
+			// Add scripts to BuddyPress registration page.
+			// We fire BP-specific code on a BP-specific action hook.
+			add_action( 'bp_init',  array( __CLASS__, 'enqueue_script' )  );
+
+			// Adds the CAPTCHA to the BuddyPress registration form
+			// Allow theme/plugin authors the opportunity to change the display priority,
+			// so that the CAPTCHA appears where needed. (We assume near the submit button.)
+			$hook_priority = apply_filters( 'ncr_bp_captcha_display_priority', 95 );
+			add_action( 'bp_before_registration_submit_buttons', array( __CLASS__, 'display_captcha' ), $hook_priority );
+
+			// Authenticate the captcha answer.
+			add_action( 'bp_signup_validate', array( __CLASS__, 'validate_captcha_registration_field' ) );
+		}
+	}
+
+	/**
+	 * Enqueue needed scripts on BuddyPress' registration page.
+	 *
+	 * @since 1.0.3
+	 */
+	public static function enqueue_script() {
+		if ( bp_is_register_page() ) {
+			// Add the Google reCAPTCHA script.
+			add_action( 'wp_enqueue_scripts', array( __CLASS__, 'enqueue_header_script' ) );
+		}
+	}
+
+	/**
+	 * Wrap the standard reCAPTCHA form field in typical BP registration form container markup.
+	 *
+	 * @since 1.0.3
+	 */
+	public static function display_captcha() {
+		$section_class = apply_filters( 'ncr_bp_register_section_class', 'register-section' );
+		?>
+		<div class="<?php echo $section_class; ?>" id="robot-check">
+			<h4><?php _e( 'Verify that you are a human.', self::$textdomain ); ?></h4>
+		<?php
+		parent::display_captcha();
+		do_action( 'bp_failed_recaptcha_verification_errors' );
+		echo '</div>';
+	}
+
+	/**
+	 * Verify the captcha answer
+	 *
+	 * @since 1.0.3
+	 *
+	 * @return void Adds error element to BP's signup errors object.
+	 */
+	public static function validate_captcha_registration_field() {
+		if ( ! isset( $_POST['g-recaptcha-response'] ) || ! self::captcha_verification() ) {
+			buddypress()->signup->errors['failed_recaptcha_verification'] = self::$error_message;
+		}
+	}
+}

--- a/no-captcha-recaptcha.php
+++ b/no-captcha-recaptcha.php
@@ -4,7 +4,7 @@
 Plugin Name: No CAPTCHA reCAPTCHA
 Plugin URI: http://w3guy.com
 Description: Protect WordPress login, registration and comment form from spam with the new No CAPTCHA reCAPTCHA
-Version: 1.0.2
+Version: 1.0.3
 Author: Agbonghama Collins
 Author URI: http://w3guy.com
 License: GPL2
@@ -14,6 +14,7 @@ Domain Path: /lang/
 
 require_once 'base-class.php';
 require_once 'registration.php';
+require_once 'buddypress-registration.php';
 require_once 'comment-form.php';
 require_once 'login.php';
 require_once 'settings.php';
@@ -24,6 +25,7 @@ register_uninstall_hook( __FILE__, array( 'Ncr_No_Captcha_Recaptcha', 'on_uninst
 
 Ncr_No_Captcha_Recaptcha::initialize();
 Ncr_Registration_Captcha::initialize();
+Ncr_BP_Registration_Captcha::initialize();
 Ncr_Comment_Captcha::initialize();
 Ncr_Login_Captcha::initialize();
 Ncr_Settings_Page::initialize();

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 === Plugin Name ===
-Contributors: collizo4sky, adeptplus
+Contributors: Collizo4sky
 Donate link: https://flattr.com/submit/auto?user_id=tech4sky&url=http%3A%2F%2Fw3guy.com
 Tags: comments, spam, login, registration, captcha, recaptcha, spammers, bot
 Requires at least: 3.4

--- a/settings.php
+++ b/settings.php
@@ -344,7 +344,7 @@ class Ncr_Settings_Page {
 
 			update_option( 'ncr_options', $saved_options );
 
-			wp_redirect( '?page=ncr-config&settings-updated=true' );
+			wp_redirect( '?page=ncr-config&settings-updated=true' ); exit;
 		}
 	}
 }

--- a/settings.php
+++ b/settings.php
@@ -30,9 +30,10 @@ class Ncr_Settings_Page {
 		$site_key    = isset( $ncr_options['site_key'] ) ? $ncr_options['site_key'] : '';
 		$secrete_key = isset( $ncr_options['secrete_key'] ) ? $ncr_options['secrete_key'] : '';
 
-		$captcha_login        = isset( $ncr_options['captcha_login'] ) ? $ncr_options['captcha_login'] : '';
-		$captcha_registration = isset( $ncr_options['captcha_registration'] ) ? $ncr_options['captcha_registration'] : '';
-		$captcha_comment      = isset( $ncr_options['captcha_comment'] ) ? $ncr_options['captcha_comment'] : '';
+		$captcha_login           = isset( $ncr_options['captcha_login'] ) ? $ncr_options['captcha_login'] : '';
+		$captcha_registration    = isset( $ncr_options['captcha_registration'] ) ? $ncr_options['captcha_registration'] : '';
+		$captcha_registration_bp = isset( $ncr_options['captcha_registration_bp'] ) ? $ncr_options['captcha_registration_bp'] : '';
+		$captcha_comment         = isset( $ncr_options['captcha_comment'] ) ? $ncr_options['captcha_comment'] : '';
 
 		$theme         = isset( $ncr_options['theme'] ) ? $ncr_options['theme'] : '';
 		$language      = isset( $ncr_options['language'] ) ? $ncr_options['language'] : '';
@@ -157,6 +158,21 @@ class Ncr_Settings_Page {
 							</p>
 						</td>
 					</tr>
+					<?php if ( function_exists( 'buddypress' ) ) : ?>
+						<tr>
+							<th scope="row"><label
+									for="registration-bp"><?php _e( 'BuddyPress Registration Form', 'ncr-captcha' ); ?></label>
+							</th>
+							<td>
+								<input id="registration-bp" type="checkbox" name="ncr_options[captcha_registration_bp]"
+								       value="yes" <?php checked( $captcha_registration_bp, 'yes' ) ?>>
+
+								<p class="description">
+									<?php _e( 'Check to enable CAPTCHA on the BuddyPress registration form', 'ncr-captcha' ); ?>
+								</p>
+							</td>
+						</tr>
+					<?php endif; ?>
 				</table>
 				<p>
 					<?php wp_nonce_field( 'ncr_settings_nonce' ); ?>


### PR DESCRIPTION
Hi Collizo4sky-

I wanted to use your plugin with a BuddyPress installation, so I've extended it to provide a No CAPTCHA check on the BP registration page. Please let me know if you have any questions about how I've written the new code.

I've tested this new version pretty thoroughly with BuddyPress activated, but have not tested it extensively on a vanilla WP installation. If you run across any problems when BP is not installed or activated, please let me know.

Thanks!

-David
