### PR TITLE
Remove overzealous activation check.

### DIFF
--- a/base-class.php
+++ b/base-class.php
@@ -156,8 +156,6 @@ class Ncr_No_Captcha_Recaptcha {
 		if ( ! current_user_can( 'activate_plugins' ) ) {
 			return;
 		}
-		$plugin = isset( $_REQUEST['plugin'] ) ? $_REQUEST['plugin'] : '';
-		check_admin_referer( "activate-plugin_{$plugin}" );
 
 		$default_options = array(
 			'captcha_registration' => 'yes',


### PR DESCRIPTION
This check prevented the plugin from being activated via a PHP function call creating a conflict with the TGM Plugin Activation library.

Ref: https://github.com/TGMPA/TGM-Plugin-Activation/issues/497
